### PR TITLE
fixing pipeline flowchart image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ We've split our workflow into four parts:
 
 For each step, the script reading the config will save the output files to the corresponding outputs directory as the config.
 
-.. image:: images/pipeline_flowchart.jpg
+.. image:: images/pipeline_flowchart.png
   :width: 800
   :alt: Pipeline Flowchart
 


### PR DESCRIPTION
wrong extension before in the readme